### PR TITLE
feat(templates): preinstall lucide icon library in web react/vue templates

### DIFF
--- a/web/cloudbase-react-template/package.json
+++ b/web/cloudbase-react-template/package.json
@@ -14,7 +14,8 @@
     "@cloudbase/js-sdk": "3.4.7",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.1",
+    "lucide-react": "^1.43.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/web/cloudbase-vue-template/package.json
+++ b/web/cloudbase-vue-template/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@cloudbase/js-sdk": "latest",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "lucide-vue-next": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",


### PR DESCRIPTION
## 背景

AI agent 基于 `cloudbase-react-template` / `cloudbase-vue-template` 生成站点时，UI 需要图标。模板未内置 lucide，导致生成期必须额外执行一次包安装（`pnpm add lucide-react`）——在 sandbox / 受限环境下这一步是已知失败点（实测被 pnpm broker 拦截，最后只能手写 20+ 个 inline SVG path 兜底）。

## 改动

- `web/cloudbase-react-template`：dependencies 增加 `lucide-react: ^1.43.0`（peer 支持 react 16–19，当前模板 react 19 ✓）
- `web/cloudbase-vue-template`：dependencies 增加 `lucide-vue-next: ^1.0.0`（peer vue >= 3.0.1，当前模板 vue 3.5 ✓）

## 为什么进模板而不是生成期安装

- import 按需 tree-shake，产物只含实际用到的图标，体积增量可控（约几 MB 源码，产物增量仅为用到的 icon）
- 消除生成期唯一的运行时安装步骤：能进模板的依赖不留在生成期装
- agent 可直接 `import { Heart } from "lucide-react"`，零心智负担

## 验证

- 版本号与 peerDependencies 从 npm registry 实查（2026-09-10）
- 与模板现有依赖（react 19 / vue 3.5）兼容
